### PR TITLE
README clone and cd typofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This sample app requires that you have:
 ### Clone the repository
 
 ```bash
-git clone https://github.com/anduril/sample-app-entity-map-visualizer
+git clone https://github.com/anduril/sample-app-entity-visualizer
 cd sample-app-entity-map-visualizer
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This sample app requires that you have:
 
 ```bash
 git clone https://github.com/anduril/sample-app-entity-visualizer
-cd sample-app-entity-map-visualizer
+cd sample-app-entity-visualizer
 ```
 
 ### Edit variables


### PR DESCRIPTION
## Issue

The README's commands for `clone` and `cd` featured an incorrect repository path (`sample-app-entity-map-visualizer` vs. the correct `sample-app-entity-visualizer`).

## Change

- Revised path for both commands
- Verified locally