### PR TITLE
feat: jump map when panning

### DIFF
--- a/src/components/EntityMap.tsx
+++ b/src/components/EntityMap.tsx
@@ -18,6 +18,7 @@ export function EntityMap({ entities }: EntityMapProps) {
       zoom={5}
       scrollWheelZoom={true}
       className="map"
+      worldCopyJump={true}
     >
       <TileLayer
         attribution={TILE_ATTRIBUTION}


### PR DESCRIPTION
Previously, if a user zoomed out far enough and panned the map they could potentially miss their markers as they are not repeated across the panned map. 

This fixes this by using a Leaflet setting that jumps the user back to the repeated map that has the marker

https://github.com/user-attachments/assets/94e0b71a-5d7c-40bb-9826-077ce005f676

