### PR TITLE
feat(auth): add support for bearer token auth via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ cd sample-app-entity-visualizer
 
 ### Set variables
 
-You now need to provide the sample application with the endpoint to get data from. To do so please create a `.env` file at the root of this project folder and populate it with:
+You now need to provide the sample application with the Lattice endpoint to get data from, and credentials for it (see the [Authentication documentation](https://developer.anduril.com/guides/getting-started/authenticate)). To do so please create a `.env` file at the root of this project folder and populate it with:
 
 ```bash
-VITE_LATTICE_CLIENT_ID=""
-VITE_LATTICE_CLIENT_SECRET=""
-VITE_SANDBOX_TOKEN=""
-VITE_LATTICE_URL=""
+LATTICE_BEARER_TOKEN="" # Set this or `LATTICE_CLIENT_ID` and `LATTICE_CLIENT_SECRET`
+LATTICE_CLIENT_ID="" # Do not set `LATTICE_BEARER_TOKEN` if using client credentials
+LATTICE_CLIENT_SECRET="" # Do not set `LATTICE_BEARER_TOKEN` if using client credentials
+LATTICE_SANDBOX_TOKEN="" # Set when connecting to a Lattice Sandbox environment. Not required when connecting to other Lattice environments
+LATTICE_URL=""
 ```
 
 For information on how to obtain these credentials, see the [Sandboxes documentation](https://developer.anduril.com/guides/getting-started/sandboxes#get-the-tokens).

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ cd sample-app-entity-visualizer
 You now need to provide the sample application with the Lattice endpoint to get data from, and credentials for it (see the [Authentication documentation](https://developer.anduril.com/guides/getting-started/authenticate)). To do so please create a `.env` file at the root of this project folder and populate it with:
 
 ```bash
-LATTICE_BEARER_TOKEN="" # Set this or `LATTICE_CLIENT_ID` and `LATTICE_CLIENT_SECRET`
-LATTICE_CLIENT_ID="" # Do not set `LATTICE_BEARER_TOKEN` if using client credentials
-LATTICE_CLIENT_SECRET="" # Do not set `LATTICE_BEARER_TOKEN` if using client credentials
-LATTICE_SANDBOX_TOKEN="" # Set when connecting to a Lattice Sandbox environment. Not required when connecting to other Lattice environments
-LATTICE_URL=""
+VITE_LATTICE_BEARER_TOKEN="" # Set this or `VITE_LATTICE_CLIENT_ID` and `VITE_LATTICE_CLIENT_SECRET`
+VITE_LATTICE_CLIENT_ID="" # Do not set `VITE_LATTICE_BEARER_TOKEN` if using client credentials
+VITE_LATTICE_CLIENT_SECRET="" # Do not set `VITE_LATTICE_BEARER_TOKEN` if using client credentials
+VITE_LATTICE_SANDBOX_TOKEN="" # Set when connecting to a Lattice Sandbox environment. Not required when connecting to other Lattice environments
+VITE_LATTICE_URL=""
 ```
 
 For information on how to obtain these credentials, see the [Sandboxes documentation](https://developer.anduril.com/guides/getting-started/sandboxes#get-the-tokens).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This web application implements a custom UI with JavaScript + [Vite](https://vite.dev/) that leverages the Lattice SDK's gRPC streaming capabilities. It uses the JavaScript types generated in the [Lattice SDK Buf Repository] alongside ConnectRPC to update simulated Entity positions on a map in real-time. 
+This web application implements a custom UI with JavaScript + [Vite](https://vite.dev/) that leverages the Lattice SDK's gRPC streaming capabilities. It uses the JavaScript types generated in the [Lattice SDK Buf Repository](https://buf.build/anduril/lattice-sdk) alongside ConnectRPC to update simulated Entity positions on a map in real-time. 
 
 The project uses the following dependencies:
 * `Connect RPC` - To make the gRPC+Web requests
@@ -37,10 +37,10 @@ VITE_LATTICE_BEARER_TOKEN="" # Set this or `VITE_LATTICE_CLIENT_ID` and `VITE_LA
 VITE_LATTICE_CLIENT_ID="" # Do not set `VITE_LATTICE_BEARER_TOKEN` if using client credentials
 VITE_LATTICE_CLIENT_SECRET="" # Do not set `VITE_LATTICE_BEARER_TOKEN` if using client credentials
 VITE_LATTICE_SANDBOX_TOKEN="" # Set when connecting to a Lattice Sandbox environment. Not required when connecting to other Lattice environments
-VITE_LATTICE_URL=""
+VITE_LATTICE_URL="lattice-<sandbox_ID>.env.sandboxes.developer.anduril.com" # Your environment's Resource Endpoint
 ```
 
-For information on how to obtain these credentials, see the [Sandboxes documentation](https://developer.anduril.com/guides/getting-started/sandboxes#get-the-tokens).
+For information on how to create an environment and obtain these credentials, see the [Sandboxes documentation](https://developer.anduril.com/guides/developer-tools/sandboxes).
 
 Please contact your Anduril representative if you need assistance with populating these values or run into any authentication issues.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "globals": "^15.12.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.1",
-        "vite": "^6.4.1"
+        "vite": "^6.4.1",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1911,6 +1912,24 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2292,6 +2311,121 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2355,6 +2489,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2388,6 +2532,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2395,6 +2549,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2412,6 +2583,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clsx": {
@@ -2519,6 +2700,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2544,6 +2735,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2766,6 +2964,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2774,6 +2982,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3184,6 +3402,23 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3351,6 +3586,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3635,6 +3887,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3654,6 +3913,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3666,6 +3939,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
@@ -3698,6 +3991,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3713,6 +4020,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3871,6 +4208,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3885,6 +4318,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@buf/anduril_lattice-sdk.bufbuild_es": "^2.12.1-20260711001337-5f73f6efbade.1",
@@ -36,6 +37,7 @@
     "globals": "^15.12.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.1",
-    "vite": "^6.4.1"
+    "vite": "^6.4.1",
+    "vitest": "^3.2.7"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,18 +7,23 @@ import { EntityStore } from "./EntityStore";
 import { Entity } from "@buf/anduril_lattice-sdk.bufbuild_es/anduril/entitymanager/v1/entity.pub_pb";
 import { useEffect, useState } from "react";
 import { EntityMap } from "./components/EntityMap";
-import { Box, Container, Typography } from "@mui/material";
+import { Alert, Box, Container, Typography } from "@mui/material";
 import { DownloadLink } from "./components/DownloadLink";
 
 function App() {
   const [entities, setEntities] = useState<Entity[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const store = new EntityStore();
 
-    //Implementing the setInterval method
+    // Surface a config/connection error immediately, then keep both the
+    // entities and any error in sync on an interval.
+    setError(store.getError());
+
     const interval = setInterval(() => {
       setEntities([...store.getAllEntities().values()]);
+      setError(store.getError());
     }, 5000);
 
     //Clearing the interval
@@ -31,6 +36,11 @@ function App() {
         <Typography variant="h2" component="h1" sx={{ mb: 2 }}>
           Entity Map Visualization Tool
         </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
         <EntityMap entities={entities} />
         <DownloadLink />
       </Box>

--- a/src/EntityStore.test.ts
+++ b/src/EntityStore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/*
+    These tests exercise EntityStore's authentication wiring. We stub the
+    config module and the connect transport so no real network calls happen,
+    then assert on the headers EntityStore sends to streamEntityComponents.
+*/
+
+// Mutable config the mock below reads from, so each test can set its own creds.
+const mockConfig: Record<string, string | undefined> = {};
+
+vi.mock("./config", () => ({
+    get APPLICATION_CONFIG() {
+        return mockConfig;
+    },
+}));
+
+// Capture the arguments EntityStore passes to the streaming RPC.
+const streamCalls: unknown[][] = [];
+
+vi.mock("@connectrpc/connect", () => ({
+    createCallbackClient: () => ({
+        streamEntityComponents: (...args: unknown[]) => {
+            streamCalls.push(args);
+            return () => {};
+        },
+    }),
+}));
+
+vi.mock("@connectrpc/connect-web", () => ({
+    createGrpcWebTransport: () => ({}),
+}));
+
+async function importFreshStore() {
+    vi.resetModules();
+    const mod = await import("./EntityStore");
+    return mod.EntityStore;
+}
+
+// Pull the Headers object out of the recorded streamEntityComponents call.
+function headersFromLastStreamCall(): Headers {
+    const args = streamCalls.at(-1)!;
+    const options = args.at(-1) as { headers: Headers };
+    return options.headers;
+}
+
+describe("EntityStore authentication", () => {
+    beforeEach(() => {
+        for (const key of Object.keys(mockConfig)) delete mockConfig[key];
+        streamCalls.length = 0;
+        mockConfig.LATTICE_URL = "https://lattice.example.com";
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("uses the static bearer token directly without hitting the OAuth endpoint", async () => {
+        const fetchSpy = vi.fn();
+        vi.stubGlobal("fetch", fetchSpy);
+        mockConfig.BEARER_TOKEN = "static-token";
+
+        const EntityStore = await importFreshStore();
+        new EntityStore();
+        await vi.waitFor(() => expect(streamCalls.length).toBe(1));
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(headersFromLastStreamCall().get("authorization")).toBe("Bearer static-token");
+    });
+
+    it("exchanges client credentials at the OAuth endpoint and streams with the access token", async () => {
+        const fetchSpy = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ access_token: "exchanged-token", expires_in: 900 }),
+        });
+        vi.stubGlobal("fetch", fetchSpy);
+        mockConfig.CLIENT_ID = "id";
+        mockConfig.CLIENT_SECRET = "secret";
+
+        const EntityStore = await importFreshStore();
+        new EntityStore();
+        await vi.waitFor(() => expect(streamCalls.length).toBe(1));
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        const [url] = fetchSpy.mock.calls[0];
+        expect(url).toContain("/api/v1/oauth/token");
+        expect(headersFromLastStreamCall().get("authorization")).toBe("Bearer exchanged-token");
+    });
+
+    it("fails loudly and never streams when no credentials are configured", async () => {
+        vi.stubGlobal("fetch", vi.fn());
+
+        const EntityStore = await importFreshStore();
+        expect(() => new EntityStore()).toThrow(/no authentication/i);
+        expect(streamCalls.length).toBe(0);
+    });
+});

--- a/src/EntityStore.test.ts
+++ b/src/EntityStore.test.ts
@@ -88,11 +88,43 @@ describe("EntityStore authentication", () => {
         expect(headersFromLastStreamCall().get("authorization")).toBe("Bearer exchanged-token");
     });
 
-    it("fails loudly and never streams when no credentials are configured", async () => {
+    it("surfaces a config error without throwing when no credentials are configured", async () => {
         vi.stubGlobal("fetch", vi.fn());
 
         const EntityStore = await importFreshStore();
-        expect(() => new EntityStore()).toThrow(/no authentication/i);
+        let store!: InstanceType<typeof EntityStore>;
+        expect(() => {
+            store = new EntityStore();
+        }).not.toThrow();
+
+        expect(store.getError()).toMatch(/no authentication/i);
         expect(streamCalls.length).toBe(0);
+    });
+
+    it("surfaces a config error without throwing when both auth methods are set", async () => {
+        vi.stubGlobal("fetch", vi.fn());
+        mockConfig.BEARER_TOKEN = "static-token";
+        mockConfig.CLIENT_ID = "id";
+        mockConfig.CLIENT_SECRET = "secret";
+
+        const EntityStore = await importFreshStore();
+        let store!: InstanceType<typeof EntityStore>;
+        expect(() => {
+            store = new EntityStore();
+        }).not.toThrow();
+
+        expect(store.getError()).toMatch(/cannot be used together/i);
+        expect(streamCalls.length).toBe(0);
+    });
+
+    it("reports no error when configured correctly", async () => {
+        vi.stubGlobal("fetch", vi.fn());
+        mockConfig.BEARER_TOKEN = "static-token";
+
+        const EntityStore = await importFreshStore();
+        const store = new EntityStore();
+        await vi.waitFor(() => expect(streamCalls.length).toBe(1));
+
+        expect(store.getError()).toBeNull();
     });
 });

--- a/src/EntityStore.ts
+++ b/src/EntityStore.ts
@@ -17,16 +17,26 @@ export class EntityStore {
             baseUrl: APPLICATION_CONFIG.LATTICE_URL,
         }));
         this.entities = new Map();
-        this.getAccessToken().then(() => {
-            this.streamEntities();
-        }).catch(error => {
-            console.error("Failed to get access token:", error);
-        });
+        
+        this.getAccessToken()
+            .then(this.streamEntities)
+            .catch(console.error);
     }
 
-    private async getAccessToken(retryCount: number = 0): Promise<string> {
+    private async getAccessToken(retryCount: number = 0): Promise<undefined> {
+        if (APPLICATION_CONFIG.BEARER_TOKEN) {
+            if (APPLICATION_CONFIG.CLIENT_ID || APPLICATION_CONFIG.CLIENT_SECRET) {
+                throw new Error("Bearer token auth (`BEARER_TOKEN`) and client config auth (`CLIENT_ID` + `CLIENT_SECRET`) cannot be used together. Use only one method of authentication. Learn more at https://developer.anduril.com/guides/getting-started/authenticate");
+            }
+        }
+
+        if (APPLICATION_CONFIG.BEARER_TOKEN) {
+            this.accessToken = APPLICATION_CONFIG.BEARER_TOKEN;
+            return;
+        }
+
         if (this.accessToken && Date.now() < this.tokenExpiry) {
-            return this.accessToken;
+            return;
         }
 
         try {
@@ -56,8 +66,6 @@ export class EntityStore {
             this.tokenExpiry = Date.now() + (expirySeconds * 1000);
 
             this.scheduleTokenRefresh();
-
-            return this.accessToken ? this.accessToken : "";
         } catch (error) {
             console.error(`Error obtaining access token (attempt ${retryCount + 1}):`, error);
 
@@ -98,9 +106,7 @@ export class EntityStore {
         try {
             const headers = new Headers();
 
-            // Get fresh access token
-            const token = await this.getAccessToken();
-            headers.set("authorization", `Bearer ${token}`);
+            headers.set("authorization", `Bearer ${this.accessToken}`);
             headers.set("anduril-sandbox-authorization", `Bearer ${APPLICATION_CONFIG.SANDBOX_TOKEN}`);
 
             /*
@@ -108,7 +114,9 @@ export class EntityStore {
                 https://docs.anduril.com/guide/entity/watch#stream-entities for additional information
                 on streaming entities
             */
-            this.connection.streamEntityComponents({ includeAllComponents: true},
+            this.connection.streamEntityComponents(
+                // Request options
+                { includeAllComponents: true},
                 // Success callback
                 (res : StreamEntityComponentsResponse) => {
                     const entity = res.entityEvent?.entity;
@@ -129,7 +137,7 @@ export class EntityStore {
                             this.entities.delete(entity.entityId);
                     }
                 },
-
+                // Error callback
                 async (err) => {
                     console.error("Stream error:", err);
 
@@ -147,11 +155,12 @@ export class EntityStore {
 
                         setTimeout(() => {
                             this.getAccessToken()
-                                .then(() => this.streamEntities())
+                                .then(this.streamEntities)
                                 .catch(error => console.error("Failed to reconnect:", error));
                         }, 60000); 
                     }
                 },
+                // Request headers
                 { headers: headers }
             );
         } catch (error) {

--- a/src/EntityStore.ts
+++ b/src/EntityStore.ts
@@ -9,10 +9,11 @@ export class EntityStore {
 
     private connection : CallbackClient<typeof EntityManagerAPI>;
     private entities : Map<string, Entity>;
-    private authConfig!: AuthConfig;
+    private authConfig: AuthConfig | null = null;
     private accessToken: string | null = null;
     private tokenExpiry: number = 0;
     private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+    private error: string | null = null;
 
     constructor() {
         this.connection = createCallbackClient(EntityManagerAPI, createGrpcWebTransport({
@@ -20,18 +21,35 @@ export class EntityStore {
         }));
         this.entities = new Map();
 
-        // Validate credentials up front so misconfiguration fails loudly.
-        this.authConfig = resolveAuthConfig(APPLICATION_CONFIG);
+        // Validate credentials up front. Rather than throwing out of the
+        // constructor (which would crash the whole React app), we record the
+        // problem so the UI can surface it as a banner. See getError().
+        try {
+            this.authConfig = resolveAuthConfig(APPLICATION_CONFIG);
+        } catch (error) {
+            this.setError(error);
+            return;
+        }
 
         this.getAccessToken()
             .then(() => this.streamEntities())
-            .catch(console.error);
+            .catch((error) => this.setError(error));
+    }
+
+    private setError(error: unknown): void {
+        this.error = error instanceof Error ? error.message : String(error);
+        console.error(this.error);
+    }
+
+    /** The most recent unrecoverable error, or null if the store is healthy. */
+    getError(): string | null {
+        return this.error;
     }
 
     private async getAccessToken(retryCount: number = 0): Promise<undefined> {
         // A static bearer token is used as-is; there is no token exchange or
         // refresh. See https://developer.anduril.com/guides/getting-started/authenticate
-        if (this.authConfig.mode === "bearer") {
+        if (this.authConfig?.mode === "bearer") {
             this.accessToken = this.authConfig.token;
             return;
         }

--- a/src/EntityStore.ts
+++ b/src/EntityStore.ts
@@ -3,11 +3,13 @@ import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { CallbackClient, createCallbackClient } from "@connectrpc/connect";
 import { Entity } from "@buf/anduril_lattice-sdk.bufbuild_es/anduril/entitymanager/v1/entity.pub_pb";
 import { APPLICATION_CONFIG } from "./config";
+import { resolveAuthConfig, AuthConfig } from "./auth";
 
 export class EntityStore {
 
     private connection : CallbackClient<typeof EntityManagerAPI>;
     private entities : Map<string, Entity>;
+    private authConfig!: AuthConfig;
     private accessToken: string | null = null;
     private tokenExpiry: number = 0;
     private refreshTimer: ReturnType<typeof setTimeout> | null = null;
@@ -17,21 +19,20 @@ export class EntityStore {
             baseUrl: APPLICATION_CONFIG.LATTICE_URL,
         }));
         this.entities = new Map();
-        
+
+        // Validate credentials up front so misconfiguration fails loudly.
+        this.authConfig = resolveAuthConfig(APPLICATION_CONFIG);
+
         this.getAccessToken()
-            .then(this.streamEntities)
+            .then(() => this.streamEntities())
             .catch(console.error);
     }
 
     private async getAccessToken(retryCount: number = 0): Promise<undefined> {
-        if (APPLICATION_CONFIG.BEARER_TOKEN) {
-            if (APPLICATION_CONFIG.CLIENT_ID || APPLICATION_CONFIG.CLIENT_SECRET) {
-                throw new Error("Bearer token auth (`BEARER_TOKEN`) and client config auth (`CLIENT_ID` + `CLIENT_SECRET`) cannot be used together. Use only one method of authentication. Learn more at https://developer.anduril.com/guides/getting-started/authenticate");
-            }
-        }
-
-        if (APPLICATION_CONFIG.BEARER_TOKEN) {
-            this.accessToken = APPLICATION_CONFIG.BEARER_TOKEN;
+        // A static bearer token is used as-is; there is no token exchange or
+        // refresh. See https://developer.anduril.com/guides/getting-started/authenticate
+        if (this.authConfig.mode === "bearer") {
+            this.accessToken = this.authConfig.token;
             return;
         }
 
@@ -155,9 +156,9 @@ export class EntityStore {
 
                         setTimeout(() => {
                             this.getAccessToken()
-                                .then(this.streamEntities)
+                                .then(() => this.streamEntities())
                                 .catch(error => console.error("Failed to reconnect:", error));
-                        }, 60000); 
+                        }, 60000);
                     }
                 },
                 // Request headers

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveAuthConfig } from "./auth";
+import { resolveAuthConfig, type AuthInputs } from "./auth";
 
 describe("resolveAuthConfig", () => {
     it("selects bearer-token auth when only BEARER_TOKEN is set", () => {
@@ -29,6 +29,43 @@ describe("resolveAuthConfig", () => {
     });
 
     it("throws when client credentials are incomplete (id without secret)", () => {
-        expect(() => resolveAuthConfig({ CLIENT_ID: "id" })).toThrow(/CLIENT_SECRET/);
+        expect(() => resolveAuthConfig({ CLIENT_ID: "id" })).toThrow(
+            /VITE_LATTICE_CLIENT_SECRET/,
+        );
+    });
+
+    /*
+        The banner shows these messages verbatim, so they have to name the
+        `VITE_`-prefixed variables. Vite does not expose unprefixed vars to the
+        browser, so an unprefixed name in an error would misdirect the reader.
+    */
+    it("names only VITE_-prefixed environment variables in error messages", () => {
+        const failures: AuthInputs[] = [
+            {},
+            { CLIENT_ID: "id" },
+            { CLIENT_SECRET: "secret" },
+            { BEARER_TOKEN: "t", CLIENT_ID: "id" },
+            { BEARER_TOKEN: "t", CLIENT_ID: "id", CLIENT_SECRET: "secret" },
+        ];
+
+        for (const input of failures) {
+            let message = "";
+            expect(() => {
+                try {
+                    resolveAuthConfig(input);
+                } catch (e) {
+                    message = (e as Error).message;
+                    throw e;
+                }
+            }).toThrow();
+
+            const named = message.match(/\b[A-Z][A-Z0-9_]{3,}\b/g) ?? [];
+            expect(named.length).toBeGreaterThan(0);
+            for (const name of named) {
+                expect(name, `error for ${JSON.stringify(input)}: ${message}`).toMatch(
+                    /^VITE_LATTICE_/,
+                );
+            }
+        }
     });
 });

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { resolveAuthConfig } from "./auth";
+
+describe("resolveAuthConfig", () => {
+    it("selects bearer-token auth when only BEARER_TOKEN is set", () => {
+        const result = resolveAuthConfig({ BEARER_TOKEN: "my-token" });
+        expect(result).toEqual({ mode: "bearer", token: "my-token" });
+    });
+
+    it("selects client-credentials auth when only CLIENT_ID and CLIENT_SECRET are set", () => {
+        const result = resolveAuthConfig({ CLIENT_ID: "id", CLIENT_SECRET: "secret" });
+        expect(result).toEqual({ mode: "client_credentials" });
+    });
+
+    it("throws when both bearer token and client credentials are set", () => {
+        expect(() =>
+            resolveAuthConfig({ BEARER_TOKEN: "t", CLIENT_ID: "id", CLIENT_SECRET: "secret" }),
+        ).toThrow(/cannot be used together/i);
+    });
+
+    it("throws when a bearer token is combined with only a client id", () => {
+        expect(() => resolveAuthConfig({ BEARER_TOKEN: "t", CLIENT_ID: "id" })).toThrow(
+            /cannot be used together/i,
+        );
+    });
+
+    it("throws a helpful error when no credentials are configured", () => {
+        expect(() => resolveAuthConfig({})).toThrow(/no authentication/i);
+    });
+
+    it("throws when client credentials are incomplete (id without secret)", () => {
+        expect(() => resolveAuthConfig({ CLIENT_ID: "id" })).toThrow(/CLIENT_SECRET/);
+    });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -25,6 +25,18 @@ export type AuthConfig =
 
 const AUTH_DOCS = "https://developer.anduril.com/guides/getting-started/authenticate";
 
+/*
+    Error messages name the environment variables a user actually has to set,
+    not the keys of `AuthInputs`. Vite only exposes `VITE_`-prefixed vars to the
+    browser, so an error telling someone to set `BEARER_TOKEN` would send them
+    to a variable the app can never read.
+*/
+const ENV_VAR: Record<keyof AuthInputs, string> = {
+    BEARER_TOKEN: "VITE_LATTICE_BEARER_TOKEN",
+    CLIENT_ID: "VITE_LATTICE_CLIENT_ID",
+    CLIENT_SECRET: "VITE_LATTICE_CLIENT_SECRET",
+};
+
 export function resolveAuthConfig(config: AuthInputs): AuthConfig {
     const hasBearer = Boolean(config.BEARER_TOKEN);
     const hasClientId = Boolean(config.CLIENT_ID);
@@ -32,8 +44,8 @@ export function resolveAuthConfig(config: AuthInputs): AuthConfig {
 
     if (hasBearer && (hasClientId || hasClientSecret)) {
         throw new Error(
-            `Bearer token auth (\`BEARER_TOKEN\`) and client credentials auth ` +
-                `(\`CLIENT_ID\` + \`CLIENT_SECRET\`) cannot be used together. ` +
+            `Bearer token auth (\`${ENV_VAR.BEARER_TOKEN}\`) and client credentials auth ` +
+                `(\`${ENV_VAR.CLIENT_ID}\` + \`${ENV_VAR.CLIENT_SECRET}\`) cannot be used together. ` +
                 `Use only one method of authentication. Learn more at ${AUTH_DOCS}`,
         );
     }
@@ -45,15 +57,16 @@ export function resolveAuthConfig(config: AuthInputs): AuthConfig {
     if (hasClientId || hasClientSecret) {
         if (!hasClientId || !hasClientSecret) {
             throw new Error(
-                `Client credentials auth requires both \`CLIENT_ID\` and ` +
-                    `\`CLIENT_SECRET\`. Learn more at ${AUTH_DOCS}`,
+                `Client credentials auth requires both \`${ENV_VAR.CLIENT_ID}\` and ` +
+                    `\`${ENV_VAR.CLIENT_SECRET}\`. Learn more at ${AUTH_DOCS}`,
             );
         }
         return { mode: "client_credentials" };
     }
 
     throw new Error(
-        `No authentication configured. Set \`BEARER_TOKEN\`, or \`CLIENT_ID\` ` +
-            `and \`CLIENT_SECRET\`. Learn more at ${AUTH_DOCS}`,
+        `No authentication configured. Set \`${ENV_VAR.BEARER_TOKEN}\`, or ` +
+            `\`${ENV_VAR.CLIENT_ID}\` and \`${ENV_VAR.CLIENT_SECRET}\`. ` +
+            `Learn more at ${AUTH_DOCS}`,
     );
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,59 @@
+/*
+    Auth-method resolution for connecting to a Lattice environment.
+
+    Lattice supports two mutually-exclusive ways to authenticate (see
+    https://developer.anduril.com/guides/getting-started/authenticate):
+
+      - Bearer token: a long-lived, static token passed directly on every
+        request. No token exchange happens.
+      - Client credentials: a client id + secret exchanged at the OAuth
+        endpoint for short-lived access tokens that must be refreshed.
+
+    This function validates the configured credentials up front and reports a
+    clear error, rather than failing deep inside the request path.
+*/
+
+export interface AuthInputs {
+    BEARER_TOKEN?: string;
+    CLIENT_ID?: string;
+    CLIENT_SECRET?: string;
+}
+
+export type AuthConfig =
+    | { mode: "bearer"; token: string }
+    | { mode: "client_credentials" };
+
+const AUTH_DOCS = "https://developer.anduril.com/guides/getting-started/authenticate";
+
+export function resolveAuthConfig(config: AuthInputs): AuthConfig {
+    const hasBearer = Boolean(config.BEARER_TOKEN);
+    const hasClientId = Boolean(config.CLIENT_ID);
+    const hasClientSecret = Boolean(config.CLIENT_SECRET);
+
+    if (hasBearer && (hasClientId || hasClientSecret)) {
+        throw new Error(
+            `Bearer token auth (\`BEARER_TOKEN\`) and client credentials auth ` +
+                `(\`CLIENT_ID\` + \`CLIENT_SECRET\`) cannot be used together. ` +
+                `Use only one method of authentication. Learn more at ${AUTH_DOCS}`,
+        );
+    }
+
+    if (hasBearer) {
+        return { mode: "bearer", token: config.BEARER_TOKEN! };
+    }
+
+    if (hasClientId || hasClientSecret) {
+        if (!hasClientId || !hasClientSecret) {
+            throw new Error(
+                `Client credentials auth requires both \`CLIENT_ID\` and ` +
+                    `\`CLIENT_SECRET\`. Learn more at ${AUTH_DOCS}`,
+            );
+        }
+        return { mode: "client_credentials" };
+    }
+
+    throw new Error(
+        `No authentication configured. Set \`BEARER_TOKEN\`, or \`CLIENT_ID\` ` +
+            `and \`CLIENT_SECRET\`. Learn more at ${AUTH_DOCS}`,
+    );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 export const APPLICATION_CONFIG = {
-    LATTICE_URL: import.meta.env.VITE_LATTICE_URL,
-    CLIENT_ID: import.meta.env.VITE_LATTICE_CLIENT_ID,
-    CLIENT_SECRET: import.meta.env.VITE_LATTICE_CLIENT_SECRET,
-    SANDBOX_TOKEN: import.meta.env.VITE_SANDBOX_TOKEN
+    LATTICE_URL: import.meta.env.LATTICE_URL,
+    CLIENT_ID: import.meta.env.LATTICE_CLIENT_ID,
+    CLIENT_SECRET: import.meta.env.LATTICE_CLIENT_SECRET,
+    BEARER_TOKEN: import.meta.env.LATTICE_BEARER_TOKEN,
+    SANDBOX_TOKEN: import.meta.env.LATTICE_SANDBOX_TOKEN
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 export const APPLICATION_CONFIG = {
-    LATTICE_URL: import.meta.env.LATTICE_URL,
-    CLIENT_ID: import.meta.env.LATTICE_CLIENT_ID,
-    CLIENT_SECRET: import.meta.env.LATTICE_CLIENT_SECRET,
-    BEARER_TOKEN: import.meta.env.LATTICE_BEARER_TOKEN,
-    SANDBOX_TOKEN: import.meta.env.LATTICE_SANDBOX_TOKEN
+    LATTICE_URL: import.meta.env.VITE_LATTICE_URL,
+    CLIENT_ID: import.meta.env.VITE_LATTICE_CLIENT_ID,
+    CLIENT_SECRET: import.meta.env.VITE_LATTICE_CLIENT_SECRET,
+    BEARER_TOKEN: import.meta.env.VITE_LATTICE_BEARER_TOKEN,
+    SANDBOX_TOKEN: import.meta.env.VITE_LATTICE_SANDBOX_TOKEN
 }

--- a/src/vite-config.test.ts
+++ b/src/vite-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import configFn from "../vite.config";
+
+/*
+    Vite only exposes env vars to client code (import.meta.env) when they match
+    `envPrefix`, which defaults to "VITE_". Since this app reads unprefixed
+    LATTICE_* variables in src/config.ts, the vite config MUST widen envPrefix
+    to include "LATTICE_", otherwise every value is `undefined` at runtime.
+*/
+describe("vite config env prefix", () => {
+    it("exposes LATTICE_-prefixed env vars to client code", () => {
+        // defineConfig receives a function; call it the way Vite does.
+        const config = (configFn as unknown as (env: { mode: string; command: string }) => {
+            envPrefix?: string | string[];
+        })({ mode: "development", command: "serve" });
+
+        const prefixes = Array.isArray(config.envPrefix)
+            ? config.envPrefix
+            : [config.envPrefix];
+
+        expect(prefixes).toContain("LATTICE_");
+    });
+});

--- a/src/vite-config.test.ts
+++ b/src/vite-config.test.ts
@@ -1,23 +1,24 @@
 import { describe, it, expect } from "vitest";
-import configFn from "../vite.config";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /*
     Vite only exposes env vars to client code (import.meta.env) when they match
-    `envPrefix`, which defaults to "VITE_". Since this app reads unprefixed
-    LATTICE_* variables in src/config.ts, the vite config MUST widen envPrefix
-    to include "LATTICE_", otherwise every value is `undefined` at runtime.
+    `envPrefix`, which defaults to "VITE_". This app relies on that default
+    (vite.config.ts sets no envPrefix override), so every variable that
+    src/config.ts reads MUST be VITE_-prefixed — otherwise it is silently
+    `undefined` in the browser. This test guards against that regression.
 */
-describe("vite config env prefix", () => {
-    it("exposes LATTICE_-prefixed env vars to client code", () => {
-        // defineConfig receives a function; call it the way Vite does.
-        const config = (configFn as unknown as (env: { mode: string; command: string }) => {
-            envPrefix?: string | string[];
-        })({ mode: "development", command: "serve" });
+describe("config env vars use the VITE_ prefix", () => {
+    it("reads only VITE_-prefixed vars from import.meta.env", () => {
+        const configPath = fileURLToPath(new URL("./config.ts", import.meta.url));
+        const source = readFileSync(configPath, "utf8");
 
-        const prefixes = Array.isArray(config.envPrefix)
-            ? config.envPrefix
-            : [config.envPrefix];
+        const referenced = [...source.matchAll(/import\.meta\.env\.(\w+)/g)].map((m) => m[1]);
 
-        expect(prefixes).toContain("LATTICE_");
+        expect(referenced.length).toBeGreaterThan(0);
+        for (const name of referenced) {
+            expect(name.startsWith("VITE_"), `${name} must start with VITE_`).toBe(true);
+        }
     });
 });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,5 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vitest/globals", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "vitest.config.ts", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const baseUrl = env.VITE_LATTICE_URL;
+  const baseUrl = env.LATTICE_URL;
 
   const proxy : Record<string, string | ProxyOptions> = {};
   proxy[`/${baseUrl}`] = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    // This app reads unprefixed LATTICE_* env vars (see src/config.ts). Vite
+    // only exposes vars matching envPrefix to import.meta.env, and the default
+    // is "VITE_", so we must widen it to include "LATTICE_".
+    envPrefix: ['VITE_', 'LATTICE_'],
     server: {
       proxy
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const baseUrl = env.LATTICE_URL;
+  const baseUrl = env.VITE_LATTICE_URL;
 
   const proxy : Record<string, string | ProxyOptions> = {};
   proxy[`/${baseUrl}`] = {
@@ -14,10 +14,6 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
-    // This app reads unprefixed LATTICE_* env vars (see src/config.ts). Vite
-    // only exposes vars matching envPrefix to import.meta.env, and the default
-    // is "VITE_", so we must widen it to include "LATTICE_".
-    envPrefix: ['VITE_', 'LATTICE_'],
     server: {
       proxy
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Test runner config. Kept separate from vite.config.ts so the app's dev
+// server proxy setup doesn't run during tests.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
- Adds configuration to support using either Bearer tokens or Client credentials for auth
- Cleaned up the code a little bit to make it clear that the access token should be accessed at `this.accessToken` and that `getAccessToken` should not return a value
- Added tests

<img width="1083" height="958" alt="Screenshot 2026-07-17 at 00 19 38" src="https://github.com/user-attachments/assets/70a651d5-3495-4994-9030-8ddd53385e4f" />
