### PR TITLE
chore(README): use npm ci instead of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please contact your Anduril representative if you need assistance with populatin
 ### Run the application
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 


### PR DESCRIPTION
`npm install` will change the local lock file. [`npm ci`](https://docs.npmjs.com/cli/v8/commands/npm-ci) ensures only exactly what is in the `package-lock.json` file is installed